### PR TITLE
修改产测路由器配置信息

### DIFF
--- a/source/zh-cn/deviceDev/产测工具使用文档.md
+++ b/source/zh-cn/deviceDev/产测工具使用文档.md
@@ -60,18 +60,16 @@ title: 产测工具使用文档
 4.4.厂测之前需要配置路由器的信息，按照如下信息配置：
 
 
-|SSID|GIZWITS_TEST_1（或者GIZWITS_TEST_2）|
+|SSID|GIZWITS_TEST_1|
 |--|--|
 |Password|GIZWITS_TEST_PASS|
 |加密方式|WPA2PSK|
-
-在产测过程中可以使用两个路由器来进行测试，分别设置ssid为GIZWITS_TEST_1或者GIZWITS_TEST_2，密码一致。测试过程中，模组会随机连接两个路由器，提高产测效率。
 
 4.5.产测路由器不能处于级联模式，必须使用独立路由器进行产测。
 
 # 开始产测
 
-把设备配置成厂测模式，这时候设备的wifi模组会自动连上GIZWITS_TEST_1或者GIZWITS_TEST_2路由器。装有厂测APP的手机也需要连到这个路由器。
+把设备配置成厂测模式，这时候设备的wifi模组会自动连上GIZWITS_TEST_1路由器。装有厂测APP的手机也需要连到这个路由器。
 
   ![name](/assets/zh-cn/deviceDev/debug/test/1478082261395.png)
 


### PR DESCRIPTION
产测路由器配置信息，因模组27版本以上不支持连接GIZWITS_TEST_2，故删除该说明